### PR TITLE
Rate limit

### DIFF
--- a/include/btp.h
+++ b/include/btp.h
@@ -11,7 +11,7 @@
 
 #include <iwlib.h>
 
-#define MTU 1500
+#define MTU 1200
 #define BTP_HEADER_SIZE sizeof(eth_btp_t)
 #define BTP_PAYLOAD_HEADER_SIZE (sizeof(btp_payload_t) + BTP_HEADER_SIZE)
 #define MAX_PAYLOAD (MTU - (BTP_PAYLOAD_HEADER_SIZE))

--- a/include/tree.h
+++ b/include/tree.h
@@ -5,8 +5,7 @@
 #include "hashmap.h"
 
 #define MAX_BREADTH 10
-#define MAX_DEPTH 20
-#define MAX_TTL ((MAX_DEPTH * 2) + 1)
+#define MAX_TTL 10
 #define HASHMAP_KEY_SIZE 18
 
 /**

--- a/include/tree.h
+++ b/include/tree.h
@@ -50,6 +50,7 @@ typedef struct {
     uint8_t round_unchanged_cnt; // counter for game rounds without topology changes. if reaches max, game ends
     char if_name[IFNAMSIZ]; // the interface name to be used
     int sockfd;
+    uint16_t seq_num; // the current sending offset of the payload
 } self_t;
 
 #endif // __TREE_H__


### PR DESCRIPTION
Using bigger payloads caused so many collisions that made this protocol nearly useless. With this rate_limit patch data frames are rate limited per sequence number, reducing collisions and making the protocol useful.